### PR TITLE
Dont fire 'Played Story from Queue' event when resuming

### DIFF
--- a/addon/services/listen-analytics.js
+++ b/addon/services/listen-analytics.js
@@ -139,14 +139,14 @@ export default Service.extend({
       story
     });
 
-    if (playContext === 'queue' || playContext === 'history') {
+    if (action === 'start' && (playContext === 'queue' || playContext === 'history')) {
       this._trackPlayerEvent({
         action: 'Played Story from Queue',
         label: get(story, 'title'),
         story
       });
     }
-    
+
     if (!fromClick) {
       this._trackPlayerEvent({
         action: `Played Story "${get(story, 'title')}"`,


### PR DESCRIPTION
> https://jira.wnyc.org/browse/GT-85
> - Resuming a story that you initially played from the Queue fires both a "Resume" event and a second "Played Story from Queue" event

We'll only use the GTM event when a user manually clicks to resume a story that was played from queue or history. This event is just to catch the initial play.


