### PR TITLE
fixes build error on consuming app nypr-jukeboxes

### DIFF
--- a/addon/services/listen-analytics.js
+++ b/addon/services/listen-analytics.js
@@ -18,6 +18,7 @@ export default Service.extend({
 
   init() {
     this._super(...arguments);
+
     if (typeof document === 'undefined') {
       return; // don't run in fastboot
     }

--- a/addon/services/listen-analytics.js
+++ b/addon/services/listen-analytics.js
@@ -48,8 +48,6 @@ export default Service.extend({
     get(this, 'hifi').on('audio-will-fast-forward',    bind(this, '_onAudioWillFastForward'));
     get(this, 'hifi').on('current-sound-interrupted',  bind(this, '_onCurrentSoundInterrupted'));
     get(this, 'hifi').on('current-sound-changed',      bind(this, '_onCurrentSoundChanged'));
-
-    this._super(...arguments);
   },
 
   /* Monitoring hifi events and then logging analytics -------------------------

--- a/addon/services/listen-analytics.js
+++ b/addon/services/listen-analytics.js
@@ -17,6 +17,7 @@ export default Service.extend({
   sessionPing : TEN_MINUTES,
 
   init() {
+    this._super(...arguments);
     if (typeof document === 'undefined') {
       return; // don't run in fastboot
     }


### PR DESCRIPTION
Moves the call to `super.init` in the listen analytics service to the beginning of the function, which seems to fix a build error in the consuming app. 